### PR TITLE
allow customization of POST stream strategy

### DIFF
--- a/Sources/GraphQLKit/Graphiti+Router.swift
+++ b/Sources/GraphQLKit/Graphiti+Router.swift
@@ -3,8 +3,8 @@ import Graphiti
 import GraphQL
 
 extension RoutesBuilder {
-    public func register<RootType>(graphQLSchema schema: Schema<RootType, Request>, withResolver rootAPI: RootType, at path: PathComponent="graphql") {
-        self.post(path) { (request) -> EventLoopFuture<Response> in
+    public func register<RootType>(graphQLSchema schema: Schema<RootType, Request>, withResolver rootAPI: RootType, at path: PathComponent="graphql", postBodyStreamStrategy: HTTPBodyStreamStrategy = .collect) {
+        self.on(.POST, path, body: postBodyStreamStrategy) { (request) -> EventLoopFuture<Response> in
             try request.resolveByBody(graphQLSchema: schema, with: rootAPI)
                 .flatMap({
                     $0.encodeResponse(status: .ok, for: request)


### PR DESCRIPTION
hey Alex! 👋  me again.

I have a mutation for a bulk insert of many records at once, and I found I was running into Vapor's [default streaming body collection size](https://docs.vapor.codes/4.0/routing/#body-streaming).  I was able to fix it by overriding the collect stream size limit _globally_, but I'd really rather only do that for POST requests to the `/graphql` route, for obvious reasons.

This PR adds an optional configuration setting for your `register()` function, allowing a custom strategy to be passed in for the POST handler.  

I struggled with the naming of the param a bit -- as I mentioned, I didn't want to apply it to GET requests, so I called it `postBody`.  But if you can think of a better name, or if there's some other way to selectively customize this value without changing the library (maybe a middleware?), let me know. Thanks!