### PR TITLE
add register overload for variadic PathComponent

### DIFF
--- a/Sources/GraphQLKit/Graphiti+Router.swift
+++ b/Sources/GraphQLKit/Graphiti+Router.swift
@@ -1,20 +1,37 @@
-import Vapor
 import Graphiti
 import GraphQL
+import Vapor
 
-extension RoutesBuilder {
-    public func register<RootType>(graphQLSchema schema: Schema<RootType, Request>, withResolver rootAPI: RootType, at path: PathComponent="graphql", postBodyStreamStrategy: HTTPBodyStreamStrategy = .collect) {
-        self.on(.POST, path, body: postBodyStreamStrategy) { (request) -> EventLoopFuture<Response> in
+public extension RoutesBuilder {
+    func register<RootType>(
+        graphQLSchema schema: Schema<RootType, Request>,
+        withResolver rootAPI: RootType,
+        at path: PathComponent = "graphql",
+        postBodyStreamStrategy: HTTPBodyStreamStrategy = .collect
+    ) {
+        on(.POST, path, body: postBodyStreamStrategy) { request -> EventLoopFuture<Response> in
             try request.resolveByBody(graphQLSchema: schema, with: rootAPI)
-                .flatMap({
-                    $0.encodeResponse(status: .ok, for: request)
-                })
+                .flatMap { $0.encodeResponse(status: .ok, for: request) }
         }
-        self.get(path) { (request) -> EventLoopFuture<Response> in
+        get(path) { request -> EventLoopFuture<Response> in
             try request.resolveByQueryParameters(graphQLSchema: schema, with: rootAPI)
-                .flatMap({
-                    $0.encodeResponse(status: .ok, for: request)
-                })
+                .flatMap { $0.encodeResponse(status: .ok, for: request) }
+        }
+    }
+
+    func register<RootType>(
+        graphQLSchema schema: Schema<RootType, Request>,
+        withResolver rootAPI: RootType,
+        at path: PathComponent...,
+        postBodyStreamStrategy: HTTPBodyStreamStrategy = .collect
+    ) {
+        on(.POST, path, body: postBodyStreamStrategy) { request -> EventLoopFuture<Response> in
+            try request.resolveByBody(graphQLSchema: schema, with: rootAPI)
+                .flatMap { $0.encodeResponse(status: .ok, for: request) }
+        }
+        get(path) { request -> EventLoopFuture<Response> in
+            try request.resolveByQueryParameters(graphQLSchema: schema, with: rootAPI)
+                .flatMap { $0.encodeResponse(status: .ok, for: request) }
         }
     }
 }
@@ -23,4 +40,4 @@ enum GraphQLResolveError: Swift.Error {
     case noQueryFound
 }
 
-extension GraphQLResult: Content { }
+extension GraphQLResult: Content {}


### PR DESCRIPTION
In one of my apps, I'm wanting to mount several GraphQL resolvers for different API consumers, and to implement some path-based API versioning (like `/graphql/macosapp-05-2022` and `/graphql/dashboard`), but the current `register(...)` function doesn't allow passing through _variadic path components_.  Because you can't have default arguments for variadic parameters in Swift, I couldn't just changed the type to `PathComponent...`, so I added an overload.

The diff is noisier than it should be, because I ran `swift-format` on it, and it broken things up a little. I didn't touch the first function at all, it's just re-formatted.

If you'd prefer me to undo the formatting changes, I'm happy to do that, just let me know.

Or, if you don't think this is a change you want in the main library, or have a better alternative on how to implement it, I'm all ears.