### PR TITLE
Update Graphiti+Enum.swift to add missing `name` argument

### DIFF
--- a/Sources/GraphQLKit/Graphiti+Enum.swift
+++ b/Sources/GraphQLKit/Graphiti+Enum.swift
@@ -4,9 +4,9 @@ extension Enum where EnumType: CaseIterable & Encodable & RawRepresentable {
     // Initialize an enum type from a `CaseIterable` enum.
     public convenience init(
         _ type: EnumType.Type,
-        name: String? = nil
+        as name: String? = nil
     ) {
-        self.init(type) { () -> [Graphiti.Value<EnumType>] in
+        self.init(type, as: name) { () -> [Graphiti.Value<EnumType>] in
             return EnumType.allCases.map({ Value($0) })
         }
     }


### PR DESCRIPTION
Add missing `name` parameter to enum convenience initializer